### PR TITLE
Allow to set PENC value manually

### DIFF
--- a/Ruby/lib/kount/request/inquiry.rb
+++ b/Ruby/lib/kount/request/inquiry.rb
@@ -47,7 +47,7 @@ module Kount
       when 'NONE'
         params.merge!(PTOK: nil, PENC: nil)
       else
-        params[:PENC] = 'NONE'
+        params[:PENC] ||= 'NONE'
       end
     end
 


### PR DESCRIPTION
It's necessary for PayPal payments.
b/c Q-call for this case should be:

``` ruby
inquiry.add_payment(Kount::PaymentTypes::PAYPAL)
inquiry.add_params(PENC: '') # undocumented hack to handle PayPal payment w/o PayerID
```