### PR TITLE
rest-client version bump to 2.0

### DIFF
--- a/Ruby/Gemfile
+++ b/Ruby/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'rspec', '>= 3'
   gem 'simplecov', '>= 0.7'
   gem 'webmock', '>= 1.13'
-  gem 'rest-client', '>= 1.8'
+  gem 'rest-client', '>= 2.0'
 end
 
 gemspec

--- a/Ruby/kount_complete.gemspec
+++ b/Ruby/kount_complete.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('rest-client', '~> 1.8', '>= 1.8.0')
+  s.add_dependency('rest-client', '~> 2.0', '>= 2.0')
 
   s.add_development_dependency 'rspec', '~> 0'
 end


### PR DESCRIPTION
Fixed in 2.0:
RestClient::Response objects are a subclass of String rather than a Frankenstein monster. And #body or #to_s return a true String object.

Also from the rest client docs: https://github.com/rest-client/rest-client
Users are encouraged to upgrade to rest-client 2.0, which cleans up a number of API warts and wrinkles, making rest-client generally more useful. Usage is largely compatible, so many applications will be able to upgrade with no changes