### PR TITLE
Fixed Timeout Issue

### DIFF
--- a/Ruby/kount_complete.gemspec
+++ b/Ruby/kount_complete.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'kount_complete'
-  s.version     = '2.0.1'
+  s.version     = '2.0.2'
   s.summary     = "Kount Complete Services Wrapper"
   s.description = "A wrapper to facilitate making Kount RIS calls"
   s.email       = 'ruby@kount.com'

--- a/Ruby/lib/kount/client.rb
+++ b/Ruby/lib/kount/client.rb
@@ -68,7 +68,7 @@ module Kount
       begin
         response = RestClient::Resource.new(
           endpoint,
-          verify_ssl: verify_ssl_option, timeout: 1
+          verify_ssl: verify_ssl_option, timeout: timeout
         ).post params, x_kount_api_key: key
 
         JSON.parse(response)
@@ -97,6 +97,11 @@ module Kount
     # RIS Endpoint URL
     def endpoint
       @options[:endpoint]
+    end
+
+    # Timeout settings
+    def timeout
+      @options[:timeout]
     end
 
     # Merchant API for RIS acess


### PR DESCRIPTION
Fixed timeout issue. Introduced new method call `def timeout` for reading the timeout value. By default it is set to 10 sec. If merchant wants to changes it, it will override the default one.
Update `kount_complete.gemspec` file and changed the released version **2.0.1** to **2.0.2** as its the bug fixes. 