### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+---
+name: Tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', '2.4', '2.3' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rake', '>= 10.1'
 
 group :test do
   gem 'rspec', '>= 3'
-  gem 'simplecov', '~> 0.20.0'
+  gem 'simplecov', '>= 0.17'
   gem 'simplecov-json', '~> 0.2'
   gem 'webmock', '>= 1.13'
   gem 'rest-client', '>= 1.8'


### PR DESCRIPTION
To give external development teams and the wider community confidence that this project is compatible with the latest versions of Ruby, I propose using GitHub Actions for public CI and to automatically run the test suite against a matrix of supported Ruby versions.

This workflow is [passing on my fork](https://github.com/orien/kount_complete/actions/runs/7962428471), and will be added to this repo upon merge.