### PR TITLE
Remove `rest-client` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :test do
   gem 'simplecov', '~> 0.20.0'
   gem 'simplecov-json', '~> 0.2'
   gem 'webmock', '>= 1.13'
-  gem 'rest-client', '>= 1.8'
   gem 'Ascii85', '>=1.0.3'
   gem 'rubocop', '>=0.74.0'
   gem 'rubocop-rspec', '>=1.35.0'

--- a/kount_complete.gemspec
+++ b/kount_complete.gemspec
@@ -14,8 +14,4 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.5'
 
   s.required_ruby_version = '>= 2.3'
-
-  s.add_dependency 'rest-client', '>= 1.8.0', '< 3.0.0'
-
-  s.add_development_dependency 'rspec', '~> 0'
 end


### PR DESCRIPTION
### Context

This project uses the [`rest-client`](https://github.com/rest-client/rest-client) gem to make HTTP requests to the Kount Risk Inquiry Service. Unfortunately, the `rest-client` is unmaintained and abandoned. See the discussion in https://github.com/rest-client/rest-client/issues/764. The last release was [version 2.1.0](https://rubygems.org/gems/rest-client/versions/2.1.0) in 2019.

### Proposed Change

Let's replace the `rest-client` gem with `Net::HTTP` from the Ruby standard library.

### Considerations

The `rest-client` gem also uses the `Net::HTTP` library [under the hood](https://github.com/rest-client/rest-client/blob/2c72a2e77e2e87d25ff38feba0cf048d51bd5eca/lib/restclient/request.rb#L453). So, this change should be transparent for downstream users.

Fixes #26.